### PR TITLE
Feature 스케줄러기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.1.Final'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     implementation group: 'com.ullink.slack', name: 'simpleslackapi', version: '1.2.0'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.3'

--- a/src/main/java/com/example/projectprototype/config/SchedulerConfig.java
+++ b/src/main/java/com/example/projectprototype/config/SchedulerConfig.java
@@ -1,0 +1,56 @@
+package com.example.projectprototype.config;
+
+import com.example.projectprototype.scheduler.job.RoomFailManageJob;
+import com.example.projectprototype.scheduler.job.RoomSuccessManageJob;
+import org.quartz.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.CronScheduleBuilder.cronSchedule;
+import static org.quartz.TriggerBuilder.newTrigger;
+import javax.annotation.PostConstruct;
+
+@Configuration
+@PropertySource("classpath:/quartz.properties")
+public class SchedulerConfig {
+
+    private final Scheduler scheduler;
+
+    @Autowired
+    public SchedulerConfig(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @PostConstruct
+    public void schedulingJobs() {
+        JobDetail successManageDetail = newJob(RoomSuccessManageJob.class)
+                .withIdentity("SuccessManage","RoomSchedule")
+                .build();
+
+        JobDetail failManageDetail = newJob(RoomFailManageJob.class)
+                .withIdentity("FailManage","RoomSchedule")
+                .build();
+
+        Trigger successManageTrigger = newTrigger()
+                .withIdentity("SuccessManage", "RoomSchedule")
+                .withSchedule(cronSchedule("0 28/30 * * * ?"))// 매 시간 28분, 58분에 스케줄 시작
+                .forJob(successManageDetail)
+                .build();
+
+        Trigger failManageTrigger = newTrigger()
+                .withIdentity("FailManage","RoomSchedule")
+                .withSchedule(cronSchedule("0 0 1 * * ?"))
+                .forJob("FailManage","RoomSchedule")
+                .build();
+        try {
+            scheduler.scheduleJob(successManageDetail, successManageTrigger);
+            scheduler.scheduleJob(failManageDetail, failManageTrigger);
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+            //error 로깅
+        }
+
+    }
+}

--- a/src/main/java/com/example/projectprototype/entity/enums/RoomStatus.java
+++ b/src/main/java/com/example/projectprototype/entity/enums/RoomStatus.java
@@ -1,5 +1,5 @@
 package com.example.projectprototype.entity.enums;
 
 public enum RoomStatus {
-    active, succeed, failed
+    active, succeed, failed, managedFail
 }

--- a/src/main/java/com/example/projectprototype/repository/RoomRepository.java
+++ b/src/main/java/com/example/projectprototype/repository/RoomRepository.java
@@ -2,16 +2,21 @@ package com.example.projectprototype.repository;
 
 import com.example.projectprototype.entity.Room;
 import com.example.projectprototype.entity.User;
+import com.example.projectprototype.entity.enums.RoomStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     List<Room> findAll();
     List<Room> findByOwner(User user);
+    List<Room> findByStatus(RoomStatus status);
+    List<Room> findByStatusAndMeetTimeBetween(RoomStatus roomStatus, LocalDateTime fromDate, LocalDateTime toDate);
 
     @Query(value = "update room r set r.status = ?2 where r.id = ?1 ", nativeQuery = true)
     void updateStatus(Long id, String status);

--- a/src/main/java/com/example/projectprototype/scheduler/job/RoomFailManageJob.java
+++ b/src/main/java/com/example/projectprototype/scheduler/job/RoomFailManageJob.java
@@ -1,0 +1,35 @@
+package com.example.projectprototype.scheduler.job;
+
+import com.example.projectprototype.entity.Room;
+import com.example.projectprototype.entity.enums.RoomStatus;
+import com.example.projectprototype.repository.RoomRepository;
+import com.example.projectprototype.service.ChatService;
+import com.example.projectprototype.service.ChatServiceImpl;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.util.List;
+
+// fail 상태의 방의 채팅방을 삭제함.
+public class RoomFailManageJob implements Job {
+
+    private final RoomRepository roomRepository;
+    private final ChatService chatService;
+
+    RoomFailManageJob(RoomRepository roomRepository, ChatServiceImpl chatService) {
+        this.roomRepository = roomRepository;
+        this.chatService = chatService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        List<Room> rooms = roomRepository.findByStatus(RoomStatus.failed);
+        if (rooms.size() > 0) {
+            for (Room room : rooms) {
+                roomRepository.updateStatus(room.getId(), "managedFail");
+                chatService.removeChat(room.getId());
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/projectprototype/scheduler/job/RoomSuccessManageJob.java
+++ b/src/main/java/com/example/projectprototype/scheduler/job/RoomSuccessManageJob.java
@@ -1,0 +1,37 @@
+package com.example.projectprototype.scheduler.job;
+
+import com.example.projectprototype.entity.Room;
+import com.example.projectprototype.entity.enums.RoomStatus;
+import com.example.projectprototype.repository.RoomRepository;
+import com.example.projectprototype.service.ChatService;
+import com.example.projectprototype.service.ChatServiceImpl;
+import org.quartz.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// active 상태이면서, 특정 시간에 걸리는 Room 들의 상태를 succeed 로 바꾸고, 관련된 채팅방을 힙 영역에서 제거하는 작업
+public class RoomSuccessManageJob implements Job{
+
+    private final RoomRepository roomRepository;
+    private final ChatService chatService;
+
+    RoomSuccessManageJob(RoomRepository roomRepository, ChatServiceImpl chatService) {
+        this.roomRepository = roomRepository;
+        this.chatService = chatService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        LocalDateTime fromTime = LocalDateTime.now();
+        LocalDateTime toTime = fromTime.plusMinutes(10);
+        List<Room> rooms = roomRepository.findByStatusAndMeetTimeBetween(RoomStatus.active, fromTime, toTime);
+
+        if (rooms.size() > 0) {
+            for (Room room : rooms) {
+                roomRepository.updateStatus(room.getId(), "succeed"); // active 상태 방을 탐색하면서 조건에 맞으면 success 상태로 바꾸기
+                chatService.removeChat(room.getId()); // 해당 roomId key value 에 해당하는 메모리 영역 remove
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/projectprototype/scheduler/job/RoomSuccessManageJob.java
+++ b/src/main/java/com/example/projectprototype/scheduler/job/RoomSuccessManageJob.java
@@ -5,6 +5,8 @@ import com.example.projectprototype.entity.enums.RoomStatus;
 import com.example.projectprototype.repository.RoomRepository;
 import com.example.projectprototype.service.ChatService;
 import com.example.projectprototype.service.ChatServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import org.quartz.*;
 
 import java.time.LocalDateTime;
@@ -15,12 +17,15 @@ public class RoomSuccessManageJob implements Job{
 
     private final RoomRepository roomRepository;
     private final ChatService chatService;
+    private final ObjectMapper objectMapper;
 
-    RoomSuccessManageJob(RoomRepository roomRepository, ChatServiceImpl chatService) {
+    RoomSuccessManageJob(RoomRepository roomRepository, ChatServiceImpl chatService, ObjectMapper objectMapper) {
         this.roomRepository = roomRepository;
         this.chatService = chatService;
+        this.objectMapper = objectMapper;
     }
 
+    @SneakyThrows
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         LocalDateTime fromTime = LocalDateTime.now();
@@ -30,6 +35,7 @@ public class RoomSuccessManageJob implements Job{
         if (rooms.size() > 0) {
             for (Room room : rooms) {
                 roomRepository.updateStatus(room.getId(), "succeed"); // active 상태 방을 탐색하면서 조건에 맞으면 success 상태로 바꾸기
+                chatService.succeedSend(room.getId(), objectMapper); // 약속이 성사되었다는 메시지를 보냄.
                 chatService.removeChat(room.getId()); // 해당 roomId key value 에 해당하는 메모리 영역 remove
             }
         }

--- a/src/main/java/com/example/projectprototype/service/ChatService.java
+++ b/src/main/java/com/example/projectprototype/service/ChatService.java
@@ -17,4 +17,5 @@ public interface ChatService {
 	String objToJson(ChatMessageDto chatMessageDto, ObjectMapper objectMapper) throws IOException;
 	void send(WebSocketSession session, ChatMessageDto chatMessageDto, ObjectMapper objectMapper, JSONArray jsonArray) throws IOException;
 	void removeChat(Long roomId);
+	void succeedSend(Long roomId, ObjectMapper objectMapper) throws IOException;
 }

--- a/src/main/java/com/example/projectprototype/service/ChatService.java
+++ b/src/main/java/com/example/projectprototype/service/ChatService.java
@@ -16,4 +16,5 @@ public interface ChatService {
 	JSONArray loadHistory(ChatMessageDto chatMessageDto, ObjectMapper objectMapper, JSONArray jsonArray) throws IOException;
 	String objToJson(ChatMessageDto chatMessageDto, ObjectMapper objectMapper) throws IOException;
 	void send(WebSocketSession session, ChatMessageDto chatMessageDto, ObjectMapper objectMapper, JSONArray jsonArray) throws IOException;
+	void removeChat(Long roomId);
 }

--- a/src/main/java/com/example/projectprototype/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/projectprototype/service/ChatServiceImpl.java
@@ -155,4 +155,16 @@ public class ChatServiceImpl implements ChatService{
 		}
 		*/
 	}
+
+	public void removeChat(Long roomId) {
+		try {
+			// 갈비지 컬랙터가 처리하기 전에 직접 내용물을 지워줌으로써 힙 영역 용량 확보
+			if (map.get(roomId).size() > 0)
+				map.get(roomId).clear();
+			map.remove(roomId);
+		} catch (Exception e) {
+			e.printStackTrace();
+			// error 로깅
+		}
+	}
 }

--- a/src/main/java/com/example/projectprototype/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/projectprototype/service/ChatServiceImpl.java
@@ -156,6 +156,22 @@ public class ChatServiceImpl implements ChatService{
 		*/
 	}
 
+	public void succeedSend(Long roomId, ObjectMapper objectMapper) throws IOException {
+		JSONArray jsonArray = new JSONArray();
+
+		ChatMessageDto chatMessageDto = new ChatMessageDto();
+		chatMessageDto.setWriter("Admin");
+		chatMessageDto.setMessageType(MessageType.text);
+		chatMessageDto.setMessage("약속 시간이 되었습니다. 약속장소에서 만나요!");
+		chatMessageDto.setTime(LocalDateTime.now());
+
+		jsonArray.put(new JSONObject(objToJson(chatMessageDto, objectMapper)));
+		for (Map.Entry<String, WebSocketSession> userSession : (map.get(roomId).entrySet())) {
+				TextMessage textMessage = new TextMessage(objectMapper.writeValueAsString(jsonArray.toString()));
+				userSession.getValue().sendMessage(textMessage);
+			}
+		}
+
 	public void removeChat(Long roomId) {
 		try {
 			// 갈비지 컬랙터가 처리하기 전에 직접 내용물을 지워줌으로써 힙 영역 용량 확보

--- a/src/main/resources/quartz.properties
+++ b/src/main/resources/quartz.properties
@@ -1,0 +1,4 @@
+org.quartz.scheduler.instanceName = QuartzScheduler
+org.quartz.threadPool.threadCount = 10
+# For Single WAS projects, RAMStore is sufficient.
+org.quartz.jobStore.class = org.quartz.simpl.RAMJobStore


### PR DESCRIPTION
다음의 사항들이 스케줄러로 구현되었습니다.
- 방 상태를 success 로 바꾸기 (매 28분, 58분 마다 동작)
- 성사된 약속 메시지 보내기  (매 28분, 58분 마다 동작)
- 더 이상 사용하지 않는 채팅방 삭제하기 (매시간 00 분 마다 동작)

[문제]
지금은 약속 성사 메시지를 보내자마자 채팅방을 삭제하는 구조로 되어있습니다. 
즉, 완료 메시지를 보내도 사용자가 확인할 방법이 없기 때문에 혼란이 있을 것 같습니다.
따라서 채팅방을 meetTime + 30분 까지 유지하도록 해주는건 어떨까요? 
스케줄러를 하나더 만들면 구현가능할 것 같습니다. 
scheduler 1 : succeed 상태로 바뀌는 부분은 방 상태 바꾸기 + 메시지 보내기
scheduler 2 : meetTime + 30분에 채팅방 삭제 + managedSuccess 상태로 RoomStatus 바꾸기

[추가 수정]
대신 이렇게 할 경우 /myroom API 가 succeed 상태의 방까지 보여주도록 손을 좀 봐야할것 같습니다.